### PR TITLE
Removing the hacky timeout that made the extension crash at times

### DIFF
--- a/AppLinker.js
+++ b/AppLinker.js
@@ -55,22 +55,18 @@ function($, qva, qlik, angular, template, css, definition, linkerService) {
                     $scope.appItems = linkerService.getAppItems($scope.layout.props);
 
                     if ($scope.appItems.length > 0) {
+                        linkerService.getApps($scope.layout.props, $scope.appItems).then(function(apps) {
+                            return linkerService.addFieldsToApps(apps);
+                        }).then(function(apps){
+                            $scope.linkedApps = apps;
 
-                        $timeout(function() {
+                            return linkerService.getSelectedItemKeys();
+                        }).then(function(currentSelections){
+                            $scope.linkedApps = linkerService.addTransferableSelectionsToApps(currentSelections, $scope.linkedApps);
 
-                            linkerService.getApps($scope.layout.props, $scope.appItems).then(function(apps) {
-                                return linkerService.addFieldsToApps(apps);
-                            }).then(function(apps){
-                                $scope.linkedApps = apps;
-
-                                return linkerService.getSelectedItemKeys();
-                            }).then(function(currentSelections){
-                                $scope.linkedApps = linkerService.addTransferableSelectionsToApps(currentSelections, $scope.linkedApps);
-
-                                $scope.isLoading = false;
-                                $scope.selectedItemCount = currentSelections.length;
-                            });
-                        }, 1500);
+                            $scope.isLoading = false;
+                            $scope.selectedItemCount = currentSelections.length;
+                        });
                     } else {
                         // no configured apps:
                         $scope.linkedApps = [];

--- a/properties/definition.js
+++ b/properties/definition.js
@@ -5,7 +5,7 @@ define(['qlik', 'ng!$q'], function(qlik, $q) {
     function getAppList(){
         var defer = $q.defer();
 
-        qlik.getAppList(function(list){
+        qlik.getGlobal().getAppList(function(list){
             var appList = list
                 .filter(function(app){ return app.qDocId !== currApp.id })
                 .map(function(app){

--- a/services/linkerService.js
+++ b/services/linkerService.js
@@ -9,8 +9,7 @@ define(["angular", "qvangular", "qlik", "./qlikService",], function(angular, qva
     qva.service("linkerService", ["$q", "qlikService",
         function(q, qlikService) {
 
-            var appCache = {};
-            appCache['currentApp'] = qlik.currApp();
+            var thisApp = qlik.currApp(this);
 
             var config = {
                 host: window.location.hostname,
@@ -43,7 +42,7 @@ define(["angular", "qvangular", "qlik", "./qlikService",], function(angular, qva
                     var deferred = q.defer();
                     var i=0, j=0;
 
-                    qlik.getAppList(function(reply) {
+                    qlik.getGlobal().getAppList(function(reply) {
                         appItems = _.sortBy(appItems, ['app']);
                         reply = _.sortBy(reply, ['qDocId']);
 
@@ -96,10 +95,9 @@ define(["angular", "qvangular", "qlik", "./qlikService",], function(angular, qva
                 ///////////////////////////////////////////////////////////////////////////////////////////
                 getSelectedItemKeys: function() {
                     var deferred = q.defer();
-                    var app = appCache['currentApp'];
                     var fieldRegexp = /=?\[?([\w\W]*)\]?/i;
 
-                    app.getList("CurrentSelections", function(reply) {
+                    thisApp.getList("CurrentSelections", function(reply) {
                         var selections = reply.qSelectionObject.qSelections.map(function(sel){
                             return fieldRegexp.exec(sel.qField)[1];
                         });
@@ -112,12 +110,11 @@ define(["angular", "qvangular", "qlik", "./qlikService",], function(angular, qva
                 ///////////////////////////////////////////////////////////////////////////////////////////
                 getSelections: function() {
                     var deferred = q.defer();
-                    var app = appCache['currentApp'];
                     var selections = {};
 
-                    app.getList("CurrentSelections", function(reply) {
+                    thisApp.getList("CurrentSelections", function(reply) {
                         var promises = reply.qSelectionObject.qSelections.map(function(sel){
-                            return qlikService.createList(app, [sel.qField])
+                            return qlikService.createList(thisApp, [sel.qField])
                         });
 
                         q.all(promises).then(function(values){
@@ -127,7 +124,7 @@ define(["angular", "qvangular", "qlik", "./qlikService",], function(angular, qva
                                       .filter(function(o){ return o[0].qState === 'S'; })
                                       .map(function(o){ return o[0].qText; })
                                       .sort();
-                              });
+                              });                          
                               deferred.resolve(selections);
                         });
                     });


### PR DESCRIPTION
It is replaced now by a proper use of the APIs. The Global connection needs to be opened before calling the getAppList function.

Relates to #5 